### PR TITLE
Added userdir feature for files that are supposed to be read from

### DIFF
--- a/src/main/java/io/xlate/inject/PropertyFactory.java
+++ b/src/main/java/io/xlate/inject/PropertyFactory.java
@@ -38,6 +38,7 @@ import javax.enterprise.inject.spi.InjectionPoint;
 class PropertyFactory {
 
     private static final String CLASSPATH = "classpath";
+    private static final String USER_DIR = "userdir";
     final Map<String, Properties> propertiesCache;
 
     PropertyFactory() {
@@ -50,7 +51,7 @@ class PropertyFactory {
 
     URL getResourceUrl(PropertyResource annotation, Class<?> beanType) throws MalformedURLException {
         final String location = annotation.value();
-        final URL resourceUrl;
+        URL resourceUrl;
 
         if (location.isEmpty()) {
             StringBuilder resourceName = new StringBuilder(CLASSPATH);
@@ -74,8 +75,12 @@ class PropertyFactory {
                 if (scheme != null) {
                     if (CLASSPATH.equals(scheme)) {
                         resourceUrl = new URL(null, resolvedLocation, classPathHandler(beanType));
+                    } if (USER_DIR.equals(scheme)) {
+                    	
+                    	resourceUrl = new URL("file://" + System.getProperty("user.dir") + "/" + resourceId.getAuthority());
+                    	
                     } else {
-                        resourceUrl = resourceId.toURL();
+                    	resourceUrl = resourceId.toURL();
                     }
                 } else {
                     resourceUrl = new URL(null, CLASSPATH + ':' + location, classPathHandler(beanType));


### PR DESCRIPTION
In the case that I want to not have the properties packaged in a jar but also do not want to always pass java parameters. By trying to put in a file://application.properties it was always refering to the root. Putting System.getProperty("user.dir") was not possible in the Annotation as that needed to be a static parameter. Thus I have introduced the userdir:// prefix that will in turn in the PropertyFactory prepend the user.dir from System.getproperties(). If you feel this is a good aproach please accept the pull request. If you have a better solution I'd appriciate a notice for me so that I could use the library in a different way.