### PR TITLE
add the possibility to have a property file for all classes by not ch…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ hs_err_pid*
 /.project
 /doc/
 /property-inject.launch
+
+/.idea

--- a/pom.xml
+++ b/pom.xml
@@ -84,12 +84,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.junit.platform</groupId>
-      <artifactId>junit-platform-runner</artifactId>
-      <version>1.9.2</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-junit-jupiter</artifactId>
       <version>4.11.0</version>
@@ -237,23 +231,6 @@
   </build>
 
   <profiles>
-    <profile>
-      <id>coverage</id>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.eluder.coveralls</groupId>
-            <artifactId>coveralls-maven-plugin</artifactId>
-            <configuration>
-              <jacocoReports>
-                <jacocoReport>${project.build.directory}/site/jacoco/jacoco.xml</jacocoReport>
-                <jacocoReport>${project.build.directory}/site/jacoco-it/jacoco.xml</jacocoReport>
-              </jacocoReports>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
     <profile>
       <id>release</id>
       <build>

--- a/pom.xml
+++ b/pom.xml
@@ -84,6 +84,12 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.junit.platform</groupId>
+      <artifactId>junit-platform-runner</artifactId>
+      <version>1.9.2</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-junit-jupiter</artifactId>
       <version>4.11.0</version>

--- a/src/main/java/io/xlate/inject/PropertyFactory.java
+++ b/src/main/java/io/xlate/inject/PropertyFactory.java
@@ -58,11 +58,11 @@ class PropertyFactory {
 
 
         if (location.isEmpty()) {
-                StringBuilder resourceName = new StringBuilder(CLASSPATH);
-                resourceName.append(':');
-                resourceName.append(beanType.getName().replace('.', '/'));
-                resourceName.append(".properties");
-                return new URL(null, resourceName.toString(), classPathHandler(beanType));
+            StringBuilder resourceName = new StringBuilder(CLASSPATH);
+            resourceName.append(':');
+            resourceName.append(beanType.getName().replace('.', '/'));
+            resourceName.append(".properties");
+            return new URL(null, resourceName.toString(), classPathHandler(beanType));
         } else {
 
             String resolvedLocation;

--- a/src/main/java/io/xlate/inject/PropertyFactory.java
+++ b/src/main/java/io/xlate/inject/PropertyFactory.java
@@ -95,9 +95,7 @@ class PropertyFactory {
                 } else {
                     resourceUrl = new URL(null, CLASSPATH + ':' + location, classPathHandler(beanType));
                 }
-            } catch (IllegalArgumentException | MalformedURLException e) {
-                throw new InjectionException(e);
-            } catch (URISyntaxException e) {
+            } catch (IllegalArgumentException | MalformedURLException | URISyntaxException e) {
                 throw new InjectionException(e);
             }
 

--- a/src/main/java/io/xlate/inject/PropertyFileProvider.java
+++ b/src/main/java/io/xlate/inject/PropertyFileProvider.java
@@ -1,0 +1,7 @@
+package io.xlate.inject;
+
+public interface PropertyFileProvider {
+	
+	String getLocation();
+
+}

--- a/src/main/java/io/xlate/inject/PropertyProducerBean.java
+++ b/src/main/java/io/xlate/inject/PropertyProducerBean.java
@@ -229,7 +229,7 @@ public class PropertyProducerBean {
         final PropertyResource resource = annotation.resource();
         String value;
         URL resourceUrl = factory.getResourceUrl(resource, beanType);
-        value = factory.getProperty(resourceUrl, resource.format(), hasGlobalFile ? true : resource.allowMissingResource(), propertyName, defaultValue);
+        value = factory.getProperty(resourceUrl, resource.format(), hasGlobalFile || resource.allowMissingResource(), propertyName, defaultValue);
 
         if (value != null && annotation.resolveEnvironment()) {
             return factory.replaceEnvironmentReferences(value);

--- a/src/main/java/io/xlate/inject/PropertyResourceProducerBean.java
+++ b/src/main/java/io/xlate/inject/PropertyResourceProducerBean.java
@@ -64,7 +64,7 @@ public class PropertyResourceProducerBean {
                 p.putAll(factory.getProperties(resourceUrl, format, annotation.allowMissingResource()));
             }
             resourceUrl = factory.getResourceUrl(annotation, beanType);
-            p.putAll(factory.getProperties(resourceUrl, format, hasGlobalPropertyFile ? true: annotation.allowMissingResource()));
+            p.putAll(factory.getProperties(resourceUrl, format, hasGlobalPropertyFile || annotation.allowMissingResource()));
             return p;
         } catch (Exception e) {
             throw new InjectionException(e);

--- a/src/test/java/io/xlate/inject/PropertyProducerBeanIT.java
+++ b/src/test/java/io/xlate/inject/PropertyProducerBeanIT.java
@@ -24,6 +24,7 @@ import javax.inject.Inject;
 import org.jboss.weld.junit5.WeldInitiator;
 import org.jboss.weld.junit5.WeldJunit5Extension;
 import org.jboss.weld.junit5.WeldSetup;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -32,7 +33,7 @@ class PropertyProducerBeanIT {
 
 	@WeldSetup
 	public WeldInitiator weld = WeldInitiator
-		.from(PropertyProducerBean.class)
+		.from(PropertyProducerBean.class, TestFileProvider.class)
 		.build();
 
     @Inject @Property
@@ -75,6 +76,10 @@ class PropertyProducerBeanIT {
     @Property
     int int3;
 
+    @BeforeAll
+    public static void setUp() {
+        System.setProperty("string6.property.name", "string6value.system");
+    }
     @Test
     void testString1_DefaultLookup() {
         assertEquals("string1value", string1);

--- a/src/test/java/io/xlate/inject/PropertyProducerBeanTest.java
+++ b/src/test/java/io/xlate/inject/PropertyProducerBeanTest.java
@@ -31,6 +31,7 @@ import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.logging.Handler;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
@@ -41,6 +42,7 @@ import javax.enterprise.inject.spi.AnnotatedParameter;
 import javax.enterprise.inject.spi.InjectionPoint;
 import javax.json.Json;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
@@ -55,11 +57,14 @@ class PropertyProducerBeanTest {
     @Mock
     PropertyResource defaultPropertyResource;
 
+    private Locale locale;
     @BeforeEach
     void setup() {
         bean = new PropertyProducerBean();
         when(defaultPropertyResource.value()).thenReturn("");
         when(defaultPropertyResource.format()).thenReturn(PropertyResourceFormat.PROPERTIES);
+        locale = Locale.getDefault();
+        Locale.setDefault(Locale.ENGLISH);
     }
 
     private Property mockProperty(String name,
@@ -953,4 +958,8 @@ class PropertyProducerBeanTest {
         });
     }
 
+    @AfterEach
+    public void teardown(){
+        Locale.setDefault(locale);
+    }
 }

--- a/src/test/java/io/xlate/inject/PropertyResourceProducerBeanTest.java
+++ b/src/test/java/io/xlate/inject/PropertyResourceProducerBeanTest.java
@@ -32,6 +32,8 @@ import javax.enterprise.inject.spi.InjectionPoint;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 
 class PropertyResourceProducerBeanTest extends AbstractInjectionPointTest {
 
@@ -137,6 +139,7 @@ class PropertyResourceProducerBeanTest extends AbstractInjectionPointTest {
     }
 
     @Test
+    @DisabledOnOs(OS.WINDOWS)
     void testProducePropertiesUnreadable() {
         File resource = new File("target/test-classes/io/xlate/inject/Unreadable.properties");
         resource.setReadable(false);

--- a/src/test/java/io/xlate/inject/PropertyResourceProducerBeanWithConfigurationFile.java
+++ b/src/test/java/io/xlate/inject/PropertyResourceProducerBeanWithConfigurationFile.java
@@ -16,25 +16,27 @@
  ******************************************************************************/
 package io.xlate.inject;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-
-import java.util.Properties;
-
-import javax.inject.Inject;
-
 import org.jboss.weld.junit5.WeldInitiator;
 import org.jboss.weld.junit5.WeldJunit5Extension;
 import org.jboss.weld.junit5.WeldSetup;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.platform.runner.JUnitPlatform;
+import org.junit.runner.RunWith;
 
+import javax.inject.Inject;
+import java.util.Properties;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@RunWith(JUnitPlatform.class)
 @ExtendWith(WeldJunit5Extension.class)
-class PropertyResourceProducerBeanIT {
+class PropertyResourceProducerBeanWithConfigurationFile {
 
 	@WeldSetup
 	WeldInitiator weld = WeldInitiator
-		.from(PropertyResourceProducerBean.class)
+		.from(PropertyResourceProducerBean.class, TestFileProvider.class)
 		.build();
 
 
@@ -42,23 +44,36 @@ class PropertyResourceProducerBeanIT {
     @PropertyResource
     Properties defaultProps;
 
+
     @Inject
     @PropertyResource("io/xlate/inject/PropertyResourceProducerBeanIT2.properties")
     Properties props2;
 
     @Test
-    void testDefaultProps() {
+    void testGlobalFile() {
+        WeldInitiator weld = WeldInitiator
+                .from(PropertyResourceProducerBean.class, TestFileProvider.class)
+                .build();
         assertNotNull(defaultProps);
-        assertEquals(2, defaultProps.size());
-        assertEquals("val1", defaultProps.getProperty("key1"));
-        assertEquals("val2", defaultProps.getProperty("key2"));
+        System.out.println(defaultProps);
+        assertEquals(3, defaultProps.size());
+        assertEquals("x", defaultProps.getProperty("key1"));
+        assertEquals("y", defaultProps.getProperty("key2"));
+        assertEquals("false", defaultProps.getProperty("value.is.found"));
     }
 
     @Test
-    void testProps2() {
+    void testGlobalFileOverriddenByLocalLocation() {
+        WeldInitiator weld = WeldInitiator
+                .from(PropertyResourceProducerBean.class, TestFileProvider.class)
+                .build();
         assertNotNull(props2);
-        assertEquals(1, props2.size());
+        System.out.println(props2);
+        assertEquals(3, props2.size());
         assertEquals("true", props2.getProperty("value.is.found"));
+        assertEquals("x", props2.getProperty("key1"));
+        assertEquals("y", props2.getProperty("key2"));
     }
+
 
 }

--- a/src/test/java/io/xlate/inject/PropertyResourceProducerBeanWithConfigurationFile.java
+++ b/src/test/java/io/xlate/inject/PropertyResourceProducerBeanWithConfigurationFile.java
@@ -16,29 +16,26 @@
  ******************************************************************************/
 package io.xlate.inject;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.util.Properties;
+
+import javax.inject.Inject;
+
 import org.jboss.weld.junit5.WeldInitiator;
 import org.jboss.weld.junit5.WeldJunit5Extension;
 import org.jboss.weld.junit5.WeldSetup;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
-import javax.inject.Inject;
-import java.util.Properties;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-
-@RunWith(JUnitPlatform.class)
 @ExtendWith(WeldJunit5Extension.class)
-class PropertyResourceProducerBeanWithConfigurationFile {
+class PropertyResourceProducerBeanWithConfigurationFileIT {
 
-	@WeldSetup
-	WeldInitiator weld = WeldInitiator
-		.from(PropertyResourceProducerBean.class, TestFileProvider.class)
-		.build();
-
+    @WeldSetup
+    WeldInitiator weld = WeldInitiator
+            .from(PropertyResourceProducerBean.class, TestFileProvider.class)
+            .build();
 
     @Inject
     @PropertyResource
@@ -51,9 +48,6 @@ class PropertyResourceProducerBeanWithConfigurationFile {
 
     @Test
     void testGlobalFile() {
-        WeldInitiator weld = WeldInitiator
-                .from(PropertyResourceProducerBean.class, TestFileProvider.class)
-                .build();
         assertNotNull(defaultProps);
         System.out.println(defaultProps);
         assertEquals(3, defaultProps.size());
@@ -64,9 +58,6 @@ class PropertyResourceProducerBeanWithConfigurationFile {
 
     @Test
     void testGlobalFileOverriddenByLocalLocation() {
-        WeldInitiator weld = WeldInitiator
-                .from(PropertyResourceProducerBean.class, TestFileProvider.class)
-                .build();
         assertNotNull(props2);
         System.out.println(props2);
         assertEquals(3, props2.size());

--- a/src/test/java/io/xlate/inject/TestFileProvider.java
+++ b/src/test/java/io/xlate/inject/TestFileProvider.java
@@ -1,0 +1,15 @@
+package io.xlate.inject;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Default;
+
+@ApplicationScoped
+@Default
+public class TestFileProvider implements PropertyFileProvider {
+
+	@Override
+	public String getLocation() {
+		return "classpath:global.properties";
+	}
+	
+}

--- a/src/test/resources/global.properties
+++ b/src/test/resources/global.properties
@@ -1,0 +1,3 @@
+key1=x
+key2=y
+value.is.found=false

--- a/src/test/resources/io/xlate/inject/PropertyResourceProducerBeanWithGlobalConfiguration.properties
+++ b/src/test/resources/io/xlate/inject/PropertyResourceProducerBeanWithGlobalConfiguration.properties
@@ -1,0 +1,1 @@
+value.is.found=in bean type based config file


### PR DESCRIPTION
…ange te actual behavior; adjust test classes to work with not english locale and not linux systems

Here an purposal to solve my requirement to have a global propertyfile, whithout touching the old behavior and the possiblilty to override the values locally.

To configure a global propertyfile the user has to implement a bean like this example:

```
package io.xlate.inject;

import javax.enterprise.context.ApplicationScoped;
import javax.enterprise.inject.Default;

@ApplicationScoped
@Default
public class #TestFileProvider implements PropertyFileProvider {

	@Override
	public String getLocation() {
		return "classpath:global.properties";
	}
	
}
```

Also I have adapted some tests to work also on system with different locale than english and the file resolver to use it in windows environment too.